### PR TITLE
Fix dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.0.0"
-  },
-  "provide": {
+    "php": ">=7.0.0",
     "ext-mbstring": "*"
   },
   "autoload": {


### PR DESCRIPTION
This package does not provide a (polyfill) implementation of ext-mbstring. It uses ext-mbstring.